### PR TITLE
Adding a current version of preprocessing for tile based images, along with fixes to utils

### DIFF
--- a/example_analysis/preprocessing_0/tile-based/preprocessing_0_eval.ipynb
+++ b/example_analysis/preprocessing_0/tile-based/preprocessing_0_eval.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 25,
    "metadata": {
     "tags": []
    },
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 27,
    "metadata": {
     "tags": []
    },
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 28,
    "metadata": {
     "tags": []
    },
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 29,
    "metadata": {
     "tags": []
    },
@@ -192,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 30,
    "metadata": {
     "tags": []
    },
@@ -223,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 31,
    "metadata": {
     "tags": []
    },
@@ -263,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 32,
    "metadata": {
     "tags": []
    },
@@ -303,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 33,
    "metadata": {
     "tags": []
    },
@@ -368,21 +368,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 34,
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
     "# Set tested matching images\n",
-    "initial_sites = [(5,0),(186,50),(548,150),(656,174),(887,225),(1279,331)]\n",
+    "initial_sites = [(5,0),(141,32),(370,86),(896,212),(1163,270),(1599,376)]\n",
     "ph_tiles = [coord[0] for coord in initial_sites]\n",
     "sbs_tiles = [coord[1] for coord in initial_sites]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 35,
    "metadata": {
     "tags": []
    },
@@ -427,48 +427,48 @@
        "      <td>/lab/barcheese01/screens/denali/input_ph/20240...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>186</th>\n",
-       "      <td>45668.8</td>\n",
-       "      <td>-31682.3</td>\n",
-       "      <td>3149.94</td>\n",
+       "      <th>141</th>\n",
+       "      <td>41958.0</td>\n",
+       "      <td>-32393.4</td>\n",
+       "      <td>3153.32</td>\n",
        "      <td>10199</td>\n",
-       "      <td>186</td>\n",
+       "      <td>141</td>\n",
        "      <td>/lab/barcheese01/screens/denali/input_ph/20240...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>548</th>\n",
-       "      <td>27938.8</td>\n",
-       "      <td>-24870.9</td>\n",
-       "      <td>3145.88</td>\n",
+       "      <th>370</th>\n",
+       "      <td>34583.7</td>\n",
+       "      <td>-27888.2</td>\n",
+       "      <td>3149.30</td>\n",
        "      <td>10199</td>\n",
-       "      <td>548</td>\n",
+       "      <td>370</td>\n",
        "      <td>/lab/barcheese01/screens/denali/input_ph/20240...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>656</th>\n",
-       "      <td>30920.4</td>\n",
-       "      <td>-22671.7</td>\n",
-       "      <td>3144.10</td>\n",
+       "      <th>896</th>\n",
+       "      <td>36137.1</td>\n",
+       "      <td>-19008.3</td>\n",
+       "      <td>3140.90</td>\n",
        "      <td>10199</td>\n",
-       "      <td>656</td>\n",
+       "      <td>896</td>\n",
        "      <td>/lab/barcheese01/screens/denali/input_ph/20240...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>887</th>\n",
-       "      <td>42805.8</td>\n",
-       "      <td>-19061.7</td>\n",
-       "      <td>3141.40</td>\n",
+       "      <th>1163</th>\n",
+       "      <td>34690.6</td>\n",
+       "      <td>-14550.6</td>\n",
+       "      <td>3138.52</td>\n",
        "      <td>10199</td>\n",
-       "      <td>887</td>\n",
+       "      <td>1163</td>\n",
        "      <td>/lab/barcheese01/screens/denali/input_ph/20240...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1279</th>\n",
-       "      <td>38413.4</td>\n",
-       "      <td>-12357.8</td>\n",
-       "      <td>3136.84</td>\n",
+       "      <th>1599</th>\n",
+       "      <td>39219.5</td>\n",
+       "      <td>-4212.6</td>\n",
+       "      <td>3137.34</td>\n",
        "      <td>10199</td>\n",
-       "      <td>1279</td>\n",
+       "      <td>1599</td>\n",
        "      <td>/lab/barcheese01/screens/denali/input_ph/20240...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -478,22 +478,22 @@
       "text/plain": [
        "       x_data   y_data   z_data  pfs_offset  field_of_view  \\\n",
        "5     38958.4 -36815.7  3165.58       10199              5   \n",
-       "186   45668.8 -31682.3  3149.94       10199            186   \n",
-       "548   27938.8 -24870.9  3145.88       10199            548   \n",
-       "656   30920.4 -22671.7  3144.10       10199            656   \n",
-       "887   42805.8 -19061.7  3141.40       10199            887   \n",
-       "1279  38413.4 -12357.8  3136.84       10199           1279   \n",
+       "141   41958.0 -32393.4  3153.32       10199            141   \n",
+       "370   34583.7 -27888.2  3149.30       10199            370   \n",
+       "896   36137.1 -19008.3  3140.90       10199            896   \n",
+       "1163  34690.6 -14550.6  3138.52       10199           1163   \n",
+       "1599  39219.5  -4212.6  3137.34       10199           1599   \n",
        "\n",
        "                                               filename  \n",
        "5     /lab/barcheese01/screens/denali/input_ph/20240...  \n",
-       "186   /lab/barcheese01/screens/denali/input_ph/20240...  \n",
-       "548   /lab/barcheese01/screens/denali/input_ph/20240...  \n",
-       "656   /lab/barcheese01/screens/denali/input_ph/20240...  \n",
-       "887   /lab/barcheese01/screens/denali/input_ph/20240...  \n",
-       "1279  /lab/barcheese01/screens/denali/input_ph/20240...  "
+       "141   /lab/barcheese01/screens/denali/input_ph/20240...  \n",
+       "370   /lab/barcheese01/screens/denali/input_ph/20240...  \n",
+       "896   /lab/barcheese01/screens/denali/input_ph/20240...  \n",
+       "1163  /lab/barcheese01/screens/denali/input_ph/20240...  \n",
+       "1599  /lab/barcheese01/screens/denali/input_ph/20240...  "
       ]
      },
-     "execution_count": 14,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -506,7 +506,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 36,
    "metadata": {
     "tags": []
    },
@@ -551,48 +551,48 @@
        "      <td>/lab/barcheese01/screens/denali/input_sbs/c2/P...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>50</th>\n",
-       "      <td>33104.7</td>\n",
-       "      <td>-30827.4</td>\n",
-       "      <td>3129.86</td>\n",
+       "      <th>32</th>\n",
+       "      <td>41984.8</td>\n",
+       "      <td>-32380.5</td>\n",
+       "      <td>3135.30</td>\n",
        "      <td>8123</td>\n",
-       "      <td>50</td>\n",
+       "      <td>32</td>\n",
        "      <td>/lab/barcheese01/screens/denali/input_sbs/c2/P...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>150</th>\n",
-       "      <td>46501.8</td>\n",
-       "      <td>-23524.4</td>\n",
-       "      <td>3121.92</td>\n",
+       "      <th>86</th>\n",
+       "      <td>34610.5</td>\n",
+       "      <td>-27875.3</td>\n",
+       "      <td>3127.12</td>\n",
        "      <td>8123</td>\n",
-       "      <td>150</td>\n",
+       "      <td>86</td>\n",
        "      <td>/lab/barcheese01/screens/denali/input_sbs/c2/P...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>174</th>\n",
-       "      <td>27248.3</td>\n",
-       "      <td>-21887.9</td>\n",
-       "      <td>3121.66</td>\n",
+       "      <th>212</th>\n",
+       "      <td>36163.6</td>\n",
+       "      <td>-18995.7</td>\n",
+       "      <td>3120.26</td>\n",
        "      <td>8123</td>\n",
-       "      <td>174</td>\n",
+       "      <td>212</td>\n",
        "      <td>/lab/barcheese01/screens/denali/input_sbs/c2/P...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>225</th>\n",
-       "      <td>30247.8</td>\n",
-       "      <td>-17465.8</td>\n",
-       "      <td>3117.18</td>\n",
+       "      <th>270</th>\n",
+       "      <td>34717.6</td>\n",
+       "      <td>-14537.7</td>\n",
+       "      <td>3114.10</td>\n",
        "      <td>8123</td>\n",
-       "      <td>225</td>\n",
+       "      <td>270</td>\n",
        "      <td>/lab/barcheese01/screens/denali/input_sbs/c2/P...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>331</th>\n",
-       "      <td>37716.9</td>\n",
-       "      <td>-10115.6</td>\n",
-       "      <td>3118.40</td>\n",
+       "      <th>376</th>\n",
+       "      <td>39246.2</td>\n",
+       "      <td>-4199.5</td>\n",
+       "      <td>3118.04</td>\n",
        "      <td>8123</td>\n",
-       "      <td>331</td>\n",
+       "      <td>376</td>\n",
        "      <td>/lab/barcheese01/screens/denali/input_sbs/c2/P...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -602,22 +602,22 @@
       "text/plain": [
        "      x_data   y_data   z_data  pfs_offset  field_of_view  \\\n",
        "0    38985.3 -36802.7  3143.86        8123              0   \n",
-       "50   33104.7 -30827.4  3129.86        8123             50   \n",
-       "150  46501.8 -23524.4  3121.92        8123            150   \n",
-       "174  27248.3 -21887.9  3121.66        8123            174   \n",
-       "225  30247.8 -17465.8  3117.18        8123            225   \n",
-       "331  37716.9 -10115.6  3118.40        8123            331   \n",
+       "32   41984.8 -32380.5  3135.30        8123             32   \n",
+       "86   34610.5 -27875.3  3127.12        8123             86   \n",
+       "212  36163.6 -18995.7  3120.26        8123            212   \n",
+       "270  34717.6 -14537.7  3114.10        8123            270   \n",
+       "376  39246.2  -4199.5  3118.04        8123            376   \n",
        "\n",
        "                                              filename  \n",
        "0    /lab/barcheese01/screens/denali/input_sbs/c2/P...  \n",
-       "50   /lab/barcheese01/screens/denali/input_sbs/c2/P...  \n",
-       "150  /lab/barcheese01/screens/denali/input_sbs/c2/P...  \n",
-       "174  /lab/barcheese01/screens/denali/input_sbs/c2/P...  \n",
-       "225  /lab/barcheese01/screens/denali/input_sbs/c2/P...  \n",
-       "331  /lab/barcheese01/screens/denali/input_sbs/c2/P...  "
+       "32   /lab/barcheese01/screens/denali/input_sbs/c2/P...  \n",
+       "86   /lab/barcheese01/screens/denali/input_sbs/c2/P...  \n",
+       "212  /lab/barcheese01/screens/denali/input_sbs/c2/P...  \n",
+       "270  /lab/barcheese01/screens/denali/input_sbs/c2/P...  \n",
+       "376  /lab/barcheese01/screens/denali/input_sbs/c2/P...  "
       ]
      },
-     "execution_count": 15,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -637,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 37,
    "metadata": {
     "tags": []
    },
@@ -673,7 +673,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 38,
    "metadata": {
     "tags": []
    },
@@ -749,7 +749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 39,
    "metadata": {
     "tags": []
    },
@@ -776,7 +776,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 40,
    "metadata": {
     "tags": []
    },
@@ -850,7 +850,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 41,
    "metadata": {
     "tags": []
    },


### PR DESCRIPTION
This addresses a previous [issue ](https://github.com/cheeseman-lab/OpticalPooledScreens/issues/2) as well as providing an updated working version of preprocessing.

No big changes, so this should be able to be merged into main, given that that represents our default working version of code prior to large reshapes. 

@roshankern let me know what you think!